### PR TITLE
Core: Add SSL certificates #7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 API_PORT=3000
-API_URL=http://localhost:3000/api/v1/
+API_URL=https://localhost:3000/api/v1/
+CERT_DIR=/certs
+API_CERT=localhost.crt
+API_KEY=localhost.key

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ server-health-monitor.log
 cmd/api/api
 cmd/data-collector/data-collector
 config.json
+
+*.crt
+*.key

--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -1,0 +1,10 @@
+# Server Health Monitor API
+
+## Setup
+
+Open a command prompt, create a `certs` directory in the root of your hard drive. Run the following in the `certs` directory:
+
+```bash
+ openssl req -x509 -out localhost.crt -keyout localhost.key   -newkey rsa:2048 -nodes -sha256   -subj '/CN=localhost' -extensions EXT -config <( \
+   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
+```

--- a/cmd/data-collector/main.go
+++ b/cmd/data-collector/main.go
@@ -22,7 +22,7 @@ func main() {
 	log.Info("Server Health Monitor - Data Collector Tool")
 
 	// TODO: pass arguments to GetVariable
-	client, err := client.NewClient(utils.GetVariable(consts.API_URL, ""))
+	client, err := client.NewClient(utils.GetVariable(consts.API_URL))
 	if err != nil {
 		panic(err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,5 @@ services:
       - "${API_PORT}:${API_PORT}"
     env_file: .env
     restart: always
+    volumes:
+      - ${CERT_DIR}:${CERT_DIR}

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -37,6 +37,9 @@ func (s *EchoServer) Start() {
 	// Currently this server is only used for the core API so the logic below
 	// is fine here. If we need to expand this to be used in multiple locations
 	// the below can be done via first-class functions
+	e.Pre(middleware.HTTPSRedirect())
+	e.Pre(middleware.AddTrailingSlash())
+
 	e.Use(middleware.Recover())
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Output: logger.Instance().GenericLogger.Writer(),
@@ -44,8 +47,11 @@ func (s *EchoServer) Start() {
 
 	router.Setup(e)
 
-	port := utils.GetVariable(consts.API_PORT, "")
+	port := utils.GetVariable(consts.API_PORT)
 	port = fmt.Sprintf(":%s", port)
 
-	e.Logger.Fatal(e.Start(port))
+	certDir := utils.GetVariable(consts.CERT_DIR)
+	e.Logger.Fatal(e.StartTLS(port,
+		fmt.Sprintf("%s/%s", certDir, utils.GetVariable(consts.API_CERT)),
+		fmt.Sprintf("%s/%s", certDir, utils.GetVariable(consts.API_KEY))))
 }

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -4,6 +4,9 @@ const (
 	// Constant keys
 	API_URL  = "API_URL"
 	API_PORT = "API_PORT"
+	CERT_DIR = "CERT_DIR"
+	API_CERT = "API_CERT"
+	API_KEY  = "API_KEY"
 
 	// Constant filenames
 	AGENT_STORE_FILENAME = "config.json"

--- a/internal/utils/variable.go
+++ b/internal/utils/variable.go
@@ -7,9 +7,18 @@ import (
 )
 
 // GetVariable returns a value given a key.
-// The order in which GetVariable tries to read and pull values from is:
-// arguments (from CLI), environemnt variables, and finally default values
-func GetVariable(key string, args string) string {
+// GetVariable first tries to read from environment variables and will default
+// to preset values
+
+func GetVariable(key string) string {
+	return GetVariableWithArgs(key, "")
+}
+
+// GetVariableWithArgs returns a value given a key.
+// GetVariableWithArgs first tries to read from command line arguments,
+// environment variables, and will default to preset values
+
+func GetVariableWithArgs(key string, args string) string {
 	// TODO: read from arguments
 	if args != "" {
 
@@ -26,7 +35,13 @@ func getDefaultForKey(key string) string {
 	case consts.API_PORT:
 		return "3000"
 	case consts.API_URL:
-		return "http://localhost:3000/api/v1/"
+		return "https://localhost:3000/api/v1/"
+	case consts.CERT_DIR:
+		return "/certs"
+	case consts.API_CERT:
+		return "localhost.crt"
+	case consts.API_KEY:
+		return "localhost.key"
 	}
 	return ""
 }


### PR DESCRIPTION
Overview: Currently API is running on HTTPS and has some issues connecting with the data-collector which is an HTTPS client. Regardless of that issue the API should be running on HTTPS anyways. This issue solves that.
Issue: #7 

In this PR:
- API is now running on HTTPS
- Added new environment variables for certificates
- Added basic documentation on how to generate development certificates (this will be further updated once more documentation on how to setup the project is done)
- docker-compose is now using certificates as well.
- Other code cleanup